### PR TITLE
Fix issue with ReStock in 1110MH_Standardised_Switching.cfg

### DIFF
--- a/GameData/TURD/TU_MH_AllInOne/1110MH_Standardised_Switching.cfg
+++ b/GameData/TURD/TU_MH_AllInOne/1110MH_Standardised_Switching.cfg
@@ -125,7 +125,7 @@
 // Squad/Parts/Coupling/Assets
 
 // Inflatable Airlock
-@PART[InflatableAirlock]:FOR[000_Standardised_Switching]:NEEDS[TexturesUnlimited]
+@PART[InflatableAirlock]:FOR[000_Standardised_Switching]:NEEDS[TexturesUnlimited&!Restock] // fix incompatibility when ReStock is installed
 {
 	MODULE
 	{


### PR DESCRIPTION
This repository seems pretty old... but I guess I can still make a PR. 
It just fixes an issue with the game trying to give the inflatable airlock recoloring when ReStock is installed.