### PR TITLE
(Part 2) Fix issue with ReStock in 1110MH_Standardised_PBRMetallic.cfg

### DIFF
--- a/GameData/TURD/TU_MH_AllInOne/1110MH_Standardised_PBRMetallic.cfg
+++ b/GameData/TURD/TU_MH_AllInOne/1110MH_Standardised_PBRMetallic.cfg
@@ -114,7 +114,7 @@
 // Coupling
 // Squad/Parts/Coupling/Assets
 
-@PART[InflatableAirlock]:FOR[003_Standardised_Switching]:NEEDS[TexturesUnlimited]
+@PART[InflatableAirlock]:FOR[003_Standardised_Switching]:NEEDS[TexturesUnlimited&!Restock] // same fix as in other file
 {
 	@MODULE[KSPTextureSwitch],0
 	{


### PR DESCRIPTION
(second part of my first pull request... still don't know how to use GitHub yet)

This repository seems pretty old... but I guess I can still make a PR.
It just fixes an issue with the game trying to give the inflatable airlock recoloring when ReStock is installed.